### PR TITLE
build: обновить зависимость faststream до версии с CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ typing_extensions
 yookassa~=3.0.1
 uvicorn
 fastapi
-faststream==0.5.20
+faststream[cli]
 nats-py


### PR DESCRIPTION
Обновлена зависимость faststream в requirements.txt для включения CLI. Это может потребовать изменения в конфигурации среды выполнения.