### PR TITLE
fix: устранение синтаксической ошибки в common_hl.py

### DIFF
--- a/src/conv_hl/common_hl.py
+++ b/src/conv_hl/common_hl.py
@@ -58,7 +58,7 @@ common_fallbacks=[
         CommandHandler('start', main_hl.start),
         CommandHandler('help', main_hl.help_command),
         CommandHandler('reset', main_hl.reset),
-    ],
+    ]
 
 filterwarnings(action="ignore",
                message=r".*CallbackQueryHandler",


### PR DESCRIPTION
Удалены лишние запятые в списке командных обработчиков.