### PR TITLE
fix: исправить сбор текста из аргументов

### DIFF
--- a/src/handlers/main_hl.py
+++ b/src/handlers/main_hl.py
@@ -99,7 +99,7 @@ async def send_msg(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text, reply_to_message_id=update.message.message_id)
         return
     type_enter_chat_id = context.args[0]
-    text = context.args[2:]
+    text = ' '.join(context.args[2:])
     match type_enter_chat_id:
         case 'Билет':
             ticket_id = context.args[1]


### PR DESCRIPTION
Исправлена ошибка при формировании текста из аргументов контекста. Теперь текст корректно объединяется в строку с помощью метода 'join'.