### PR TITLE
Fix context cleaning sequence and event ID retrieval

### DIFF
--- a/src/handlers/error_hl.py
+++ b/src/handlers/error_hl.py
@@ -146,9 +146,6 @@ async def _error_handler_logic(update: Update,
     if update:
         await cancel_tickets_db_and_gspread(update, context)
 
-    await clean_context(context)
-    await clean_context_on_end_handler(error_hl_logger, context)
-
     message = pformat(context.bot_data, compact=True)
     error_hl_logger.info('bot_data')
     error_hl_logger.info(message)
@@ -156,3 +153,6 @@ async def _error_handler_logic(update: Update,
     message = pformat(context.user_data)
     error_hl_logger.info('user_data')
     error_hl_logger.info(message)
+
+    await clean_context(context)
+    await clean_context_on_end_handler(error_hl_logger, context)

--- a/src/handlers/ticket_hl.py
+++ b/src/handlers/ticket_hl.py
@@ -41,7 +41,7 @@ async def get_ticket(
     reserve_user_data = context.user_data['reserve_user_data']
 
     if check_entered_command(context, 'reserve'):
-        schedule_event_id = reserve_user_data.get('choose_schedule_event_ids')
+        schedule_event_id = reserve_user_data.get('choose_schedule_event_id')
         schedule_event = await db_postgres.get_schedule_event(
             context.session, schedule_event_id)
         if not schedule_event.flag_turn_in_bot:


### PR DESCRIPTION
### Summary

- Reordered the `clean_context` and `clean_context_on_end_handler` calls to ensure proper execution sequence and proper handler termination.
- Fixed an issue in the `choose_schedule_event_id` key to correctly retrieve event data, addressing incorrect behavior in reservation processing.

### Checklist

- [ ] Tests have been added, updated, or deemed unnecessary.
- [ ] Documentation has been updated where necessary.
- [ ] Changes have been reviewed and meet coding standards.