### PR TITLE
Fix event type filtering logic

### DIFF
--- a/src/api/web/routes/pages.py
+++ b/src/api/web/routes/pages.py
@@ -40,6 +40,10 @@ async def show_index(
         active_sessions_count = 0
         free_seats_child_in_filtered_sessions = 0
         free_seats_adult_in_filtered_sessions = 0
+        # type_event_id живёт на ScheduleEvent, а не на TheaterEvent —
+        # определяем тип по первому активному сеансу.
+        te_type_id = None
+        te_type_name = ''
 
         for s in e.schedule_events:
             if not s.flag_turn_in_bot:
@@ -49,6 +53,11 @@ async def show_index(
                 dt = dt.replace(tzinfo=timezone.utc)
             
             if dt >= now:
+                # Запоминаем тип из первого подходящего сеанса
+                if te_type_id is None:
+                    te_type_id = s.type_event_id
+                    te_type_name = s.type_event.name if getattr(s, 'type_event', None) else ''
+
                 dt_moscow = dt.astimezone(MOSCOW_TZ)
                 m_key = dt_moscow.strftime('%Y-%m')
                 d_key = dt_moscow.strftime('%Y-%m-%d')
@@ -73,12 +82,13 @@ async def show_index(
         if (month or date) and active_sessions_count == 0:
             continue
 
+        # Фильтр по публичным типам (аналог type_event_id.in_(PUBLIC_TYPE_EVENT_IDS))
+        if te_type_id is None or te_type_id not in PUBLIC_TYPE_EVENT_IDS:
+            continue
+
         # Собираем доступные типы по тем событиям, что прошли базовые проверки,
         # до применения фильтра type_id — чтобы селект не пустел после выбора.
-        te_type_id = e.type_event_id
-        te_type_name = e.type_event.name if getattr(e, 'type_event', None) else ''
-        if te_type_id in PUBLIC_TYPE_EVENT_IDS:
-            available_types_map.setdefault(te_type_id, te_type_name)
+        available_types_map.setdefault(te_type_id, te_type_name)
 
         # Фильтр по выбранному типу (применяется после сбора available_types)
         if type_id is not None and te_type_id != type_id:

--- a/src/db/db_postgres.py
+++ b/src/db/db_postgres.py
@@ -726,13 +726,10 @@ async def get_all_theater_events(session: AsyncSession):
 
 
 async def get_all_theater_events_actual(session: AsyncSession):
-    from settings.settings import PUBLIC_TYPE_EVENT_IDS
     query = select(TheaterEvent).where(
         or_(TheaterEvent.flag_active_repertoire == True, TheaterEvent.flag_active_bd == True),
-        TheaterEvent.type_event_id.in_(PUBLIC_TYPE_EVENT_IDS),
     ).options(
         selectinload(TheaterEvent.schedule_events),
-        selectinload(TheaterEvent.type_event),
     )
     result = await session.execute(query)
     return result.scalars().all()

--- a/src/handlers/reserve/choice.py
+++ b/src/handlers/reserve/choice.py
@@ -230,9 +230,6 @@ async def choice_show_by_repertoire(update: Update,
     schedule_events = await filter_schedule_event_by_active(schedule_events)
 
     # Фильтрация по группе:
-    REPERTOIRE_TYPE_ID = 1
-    NEW_YEAR_TYPE_ID = 2
-    INVITED_TYPE_ID = 14
     group_to_type_id = {
         repertoire: [REPERTOIRE_TYPE_ID, 'Репертуарные'],
         new_years: [NEW_YEAR_TYPE_ID, 'Новогодние'],

--- a/test/test_fastapi_web_preview.py
+++ b/test/test_fastapi_web_preview.py
@@ -40,6 +40,10 @@ def _create_mock_event(free_seats_child=10, free_seats_adult=5):
     s_event.qty_adult_nonconfirm_seat = 0
     s_event.flag_turn_in_bot = True
     s_event.theater_event = event
+    s_event.type_event_id = 1
+    type_event_mock = MagicMock()
+    type_event_mock.name = 'Репертуарный'
+    s_event.type_event = type_event_mock
     
     event.schedule_events = [s_event]
     return event
@@ -288,6 +292,8 @@ def test_index_filtering_and_button_states(monkeypatch):
     s_future.qty_child_free_seat = 10
     s_future.qty_adult_free_seat = 5
     s_future.flag_turn_in_bot = True
+    s_future.type_event_id = 1
+    s_future.type_event = MagicMock(name='Репертуарный')
     event1.schedule_events = [s_future]
     
     event2 = MagicMock()
@@ -301,6 +307,8 @@ def test_index_filtering_and_button_states(monkeypatch):
     s_past.qty_child_free_seat = 0
     s_past.qty_adult_free_seat = 0
     s_past.flag_turn_in_bot = True
+    s_past.type_event_id = 1
+    s_past.type_event = MagicMock(name='Репертуарный')
     event2.schedule_events = [s_past]
     
     with _create_client(monkeypatch) as client:
@@ -376,6 +384,8 @@ def test_index_month_filtering(monkeypatch):
     s_jan.qty_child_free_seat = 10
     s_jan.qty_adult_free_seat = 5
     s_jan.flag_turn_in_bot = True
+    s_jan.type_event_id = 1
+    s_jan.type_event = MagicMock(name='Репертуарный')
     event1.schedule_events = [s_jan]
     
     event2 = MagicMock()
@@ -389,6 +399,8 @@ def test_index_month_filtering(monkeypatch):
     s_feb.qty_child_free_seat = 5
     s_feb.qty_adult_free_seat = 2
     s_feb.flag_turn_in_bot = True
+    s_feb.type_event_id = 1
+    s_feb.type_event = MagicMock(name='Репертуарный')
     event2.schedule_events = [s_feb]
     
     with _create_client(monkeypatch) as client:


### PR DESCRIPTION
The logic for filtering event types has been corrected. It now checks the event type based on the first matching schedule, excluding non-public identifiers from available types. Tests have been updated to reflect these changes.