### PR TITLE
Update notification logic, CI actions, and add age filter feature

### DIFF
--- a/.github/workflows/push_images.yml
+++ b/.github/workflows/push_images.yml
@@ -11,26 +11,26 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:latest
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-fastapi
@@ -38,7 +38,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/baby_domik_fastapi:latest
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-migration
@@ -46,7 +46,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/baby_domik_migration:latest
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-gspread
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/baby_domik_gspread_worker:latest
       -
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile-sales

--- a/src/handlers/hooks/yookassa_hl.py
+++ b/src/handlers/hooks/yookassa_hl.py
@@ -122,24 +122,24 @@ async def processing_ticket_paid(update, context: 'ContextTypes.DEFAULT_TYPE'):
             if 'common_data' not in user_data:
                 user_data['common_data'] = {}
 
-            # Добавляем данные о мероприятии для уведомления, если их нет
-            if not user_data['common_data'].get('text_for_notification_massage'):
-                try:
-                    schedule_event_id = int(choose_schedule_event_ids[0])
-                    text_select_event = await create_str_info_by_schedule_event_id(
-                        context, schedule_event_id)
+            # Для website-бронирований ВСЕГДА перезаписываем text_for_notification_massage,
+            # т.к. user_data может содержать устаревший текст от предыдущего бронирования через бота
+            try:
+                schedule_event_id = int(choose_schedule_event_ids[0])
+                text_select_event = await create_str_info_by_schedule_event_id(
+                    context, schedule_event_id)
 
-                    ticket = await db_postgres.get_ticket(context.session, ticket_ids[0])
-                    chose_base_ticket = await db_postgres.get_base_ticket(
-                        context.session, ticket.base_ticket_id)
+                ticket = await db_postgres.get_ticket(context.session, ticket_ids[0])
+                chose_base_ticket = await db_postgres.get_base_ticket(
+                    context.session, ticket.base_ticket_id)
 
-                    text_notification = (f'{text_select_event}<br>'
-                                         f'Вариант бронирования:<br>'
-                                         f'{chose_base_ticket.name} '
-                                         f'{int(ticket.price)}руб<br>')
-                    user_data['common_data']['text_for_notification_massage'] = text_notification
-                except Exception as e:
-                    webhook_hl_logger.error(f'Ошибка при формировании текста уведомления: {e}')
+                text_notification = (f'{text_select_event}<br>'
+                                     f'Вариант бронирования:<br>'
+                                     f'{chose_base_ticket.name} '
+                                     f'{int(ticket.price)}руб<br>')
+                user_data['common_data']['text_for_notification_massage'] = text_notification
+            except Exception as e:
+                webhook_hl_logger.error(f'Ошибка при формировании текста уведомления: {e}')
 
     if int_chat_id != 0 and message_id != 0:
         try:

--- a/src/handlers/sub_hl.py
+++ b/src/handlers/sub_hl.py
@@ -1001,24 +1001,24 @@ async def get_booking_admin_text(
         reserve_user_data['original_child_text'] = ", ".join(children_names) if children_names else 'Не указано'
 
         # Восстанавливаем text_for_notification_massage для пользователя
+        # Для website-бронирований всегда перезаписываем текст, так как он может быть устаревшим
         if 'common_data' not in user_data:
             user_data['common_data'] = {}
         
-        if not user_data['common_data'].get('text_for_notification_massage'):
-            try:
-                from utilities.utl_func import create_str_info_by_schedule_event_id
-                text_select_event = await create_str_info_by_schedule_event_id(
-                    context, ticket.schedule_event_id)
-                chose_base_ticket = await db_postgres.get_base_ticket(
-                    context.session, ticket.base_ticket_id)
-                
-                text_notification = (f'{text_select_event}\n'
-                                     f'Вариант бронирования:\n'
-                                     f'{chose_base_ticket.name} '
-                                     f'{int(ticket.price)}руб\n')
-                user_data['common_data']['text_for_notification_massage'] = text_notification
-            except Exception as e:
-                sub_hl_logger.error(f"Failed to restore text_for_notification_massage in get_booking_admin_text: {e}")
+        try:
+            from utilities.utl_func import create_str_info_by_schedule_event_id
+            text_select_event = await create_str_info_by_schedule_event_id(
+                context, ticket.schedule_event_id)
+            chose_base_ticket = await db_postgres.get_base_ticket(
+                context.session, ticket.base_ticket_id)
+            
+            text_notification = (f'{text_select_event}\n'
+                                 f'Вариант бронирования:\n'
+                                 f'{chose_base_ticket.name} '
+                                 f'{int(ticket.price)}руб\n')
+            user_data['common_data']['text_for_notification_massage'] = text_notification
+        except Exception as e:
+            sub_hl_logger.error(f"Failed to restore text_for_notification_massage in get_booking_admin_text: {e}")
     else:
         reserve_user_data = user_data['reserve_user_data']
 


### PR DESCRIPTION
### Description

This pull request includes the following updates and new feature:

1. **Fixed notification text updating for bookings**  
   - Resolved an issue where outdated information was used for notifications in the `sub_hl.py` and `yookassa_hl.py` files. Booking notification texts are now always overwritten with fresh data.

2. **Updated GitHub Actions versions in `push_images.yml`**  
   - Improved compatibility and ensured the use of the latest updates by upgrading the versions of `checkout`, `login`, `buildx`, and `build-push` actions.

3. **Added audience filtering by children's age**  
   - Implemented a new feature allowing filtering of audience based on the minimum and maximum age of children. Added UI elements for range selection and updated logic for audience targeting in campaigns.

4. **Updated `.gitignore`**  
   - Excluded the `/.claude` directory to keep the repository clean.

### Checklist

- [ ] I have tested these changes locally.
- [ ] These changes have been reviewed by at least one other team member.
- [ ] Documentation has been updated as needed.